### PR TITLE
Bugfix/1 noncharacter effff

### DIFF
--- a/grammars/xml-document-type-declaration.ixml
+++ b/grammars/xml-document-type-declaration.ixml
@@ -5,7 +5,12 @@ Description: An iXML Grammar for an XML Document Type Declaration, based on http
 Author: Sheila Ellen Thomson
 Created:  2024-09-26
 
-Note: (2024-06-26) Only works for external DTD definitions.
+Note: (2024-09-26) Only works for external DTD definitions.
+
+History:
+
+	Date: 2024-09-26
+	Summary: Uncommented definition of xml-name-start-character that includes noncharacter (#EFFFF).
 } 
 
        document-type-declaration : document-type-declaration-start, space-character, root-element, external-definition?, space-character?, document-type-declaration-end, whitespace-character*.
@@ -28,19 +33,14 @@ Note: (2024-06-26) Only works for external DTD definitions.
 { Common Syntactic Constructs in XML }
 
     -whitespace-character: ( space-character | #9 | #D | #A ).
-
-
-{ Full definition temporarily commented out because of error with #EFFFF 
 -xml-name-start-character: ( ":" | uppercase-character | "_" | lowercase-character | [#C0-#D6] | [#D8-#F6] | [#F8-#2FF] | [#370-#37D] | [#37F-#1FFF] | [#200C-#200D] | [#2070-#218F] | [#2C00-#2FEF] | [#3001-#D7FF] | [#F900-#FDCF] | [#FDF0-#FFFD] | [#10000-#EFFFF] ). 
-}
--xml-name-start-character: ( ":" | uppercase-character | "_" | lowercase-character | [#C0-#D6] | [#D8-#F6] | [#F8-#2FF] | [#370-#37D] | [#37F-#1FFF] | [#200C-#200D] | [#2070-#218F] | [#2C00-#2FEF] | [#3001-#D7FF] | [#F900-#FDCF] | [#FDF0-#FFFD] ).
       -xml-name-character: ( xml-name-start-character | "-" | "." | digit | #B7 | [#0300-#036F] | [#203F-#2040] ).
                 -xml-name: xml-name-start-character, (xml-name-character)*.
                -xml-names: xml-name, (#20, xml-name)*.
-      	-xml-name-token: xml-name-character+.
+          -xml-name-token: xml-name-character+.
          -xml-name-tokens: xml-name-token, (#20, xml-name-token)*.
 
-{ Other Convenience Defnitions }
+{ Other Convenience Definitions }
      
               -digit : ["0"-"9"].
 -lowercase-character : ["a"-"z"].

--- a/grammars/xml_document_type_declaration.ixml
+++ b/grammars/xml_document_type_declaration.ixml
@@ -6,11 +6,6 @@ Author: Sheila Ellen Thomson
 Created:  2024-09-26
 
 Note: (2024-09-26) Only works for external DTD definitions.
-
-History:
-
-	Date: 2024-09-26
-	Summary: Uncommented definition of xml-name-start-character that includes noncharacter (#EFFFF).
 } 
 
        document-type-declaration : document-type-declaration-start, space-character, root-element, external-definition?, space-character?, document-type-declaration-end, whitespace-character*.
@@ -33,11 +28,16 @@ History:
 { Common Syntactic Constructs in XML }
 
     -whitespace-character: ( space-character | #9 | #D | #A ).
+
+
+{ Full definition temporarily commented out because of error with #EFFFF 
 -xml-name-start-character: ( ":" | uppercase-character | "_" | lowercase-character | [#C0-#D6] | [#D8-#F6] | [#F8-#2FF] | [#370-#37D] | [#37F-#1FFF] | [#200C-#200D] | [#2070-#218F] | [#2C00-#2FEF] | [#3001-#D7FF] | [#F900-#FDCF] | [#FDF0-#FFFD] | [#10000-#EFFFF] ). 
-      -xml-name-character: ( xml-name-start-character | "-" | "." | digit | #B7 | [#0300-#036F] | [#203F-#2040] ).
+}
+-xml-name-start-character: ["_"; L].
+      -xml-name-character: xml-name-start-character; ["-.·‿⁀"; Nd; Mn].
                 -xml-name: xml-name-start-character, (xml-name-character)*.
                -xml-names: xml-name, (#20, xml-name)*.
-          -xml-name-token: xml-name-character+.
+      	-xml-name-token: xml-name-character+.
          -xml-name-tokens: xml-name-token, (#20, xml-name-token)*.
 
 { Other Convenience Definitions }
@@ -45,4 +45,4 @@ History:
               -digit : ["0"-"9"].
 -lowercase-character : ["a"-"z"].
 -uppercase-character : ["A"-"Z"].
-    -space-character : #20.
+    -space-character : [Zs].


### PR DESCRIPTION
Changed the grammar to re-use the definitions from https://www.w3.org/community/reports/ixml/CG-FINAL-ixml-20231212/ for:

- namestart
- namefollower
- space separator (Zs)

At this point, it seems unlikely that the iXML community/implementers will extend the scope of the iXML specification to match the definition in the XML specification so this workaround effectively closes #1.